### PR TITLE
Fix NGINX Proxy Manager typo

### DIFF
--- a/_posts/2025-02-25-homelab-setup.md
+++ b/_posts/2025-02-25-homelab-setup.md
@@ -56,8 +56,8 @@ I went with Homarr as my dashboard of choice.
 
 I found it provided the best mix of simplicity and functionality for my use case thus far. The integration with services like Proxmox is a plus.
 
-### NGINX Proxy Manger
-I have previously used Traefik as my reverse proxy, however I found myself recently switching to NGINX for it's simplicity.
+### NGINX Proxy Manager
+I have previously used Traefik as my reverse proxy, however I found myself recently switching to NGINX for its simplicity.
 
 I spin up new services for testing quite often, and I found nginx's web UI super useful in comparison to Traefiks configuration for my setup.
 


### PR DESCRIPTION
## Summary
- fix heading and its phrase in homelab setup post

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556286dbc08326a5c9b708a54edf2a