### PR TITLE
Fix Disqus loader script tag

### DIFF
--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,5 +1,5 @@
 <!-- Start disqus -->
-<script src="{{ "/assets/js/disqusLoader.js" | relative_url }}" /></script>
+<script src="{{ "/assets/js/disqusLoader.js" | relative_url }}"></script>
 <div id="disqus_thread"><h3>Discussion and feedback</h3></div>
 <div class="disqus"></div>
 <script>


### PR DESCRIPTION
## Summary
- ensure Disqus loader script tag closes correctly

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855629159348326a0394fc09fa0ea0b